### PR TITLE
fix: update SDK constraint and tighten dependencies

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,20 +12,20 @@ topics:
   - ai-tools
 
 environment:
-  sdk: ^3.5.0
+  sdk: ^3.7.0
 
 dependencies:
   analyzer: ^9.0.0
-  args: ^2.4.0
-  archive: ^4.0.0
-  dart_mcp: ^0.2.0
-  http: ^1.1.0
-  path: ^1.8.0
-  stream_channel: ^2.1.0
+  args: ^2.7.0
+  archive: ^4.0.7
+  dart_mcp: ^0.4.0
+  http: ^1.6.0
+  path: ^1.9.1
+  stream_channel: ^2.1.4
 
 dev_dependencies:
-  lints: ^5.0.0
-  test: ^1.24.0
+  lints: ^6.0.0
+  test: ^1.28.0
 
 executables:
   pubdev_mcp_bridge: pubdev_mcp_bridge


### PR DESCRIPTION
## Problem
The package was receiving 0/20 points for dependency constraint lower bounds on pub.dev because of an SDK version mismatch.

## Root Cause
- `dart_mcp ^0.4.0` requires Dart SDK `^3.7.0`
- Our pubspec.yaml specified `sdk: ^3.5.0`
- This created incompatible constraints during downgrade analysis

## Changes
- Updated SDK constraint from `^3.5.0` to `^3.7.0`
- Tightened all dependency constraints using `dart pub upgrade --tighten`
- Updated dart_mcp from `^0.2.0` to `^0.4.0` (was already in use, just updating constraint)

## Verification
- ✅ `dart pub downgrade` succeeds
- ✅ `dart analyze` passes with downgraded dependencies
- ✅ `dart analyze` passes with upgraded dependencies

This should resolve the pub.dev downgrade analysis issues and achieve 20/20 points for dependency compatibility.